### PR TITLE
Mesure Shaders Compile Time

### DIFF
--- a/src/chromatic.ts
+++ b/src/chromatic.ts
@@ -571,7 +571,7 @@ export class Chromatic {
 
                 if (!PRODUCTION) {
                     endTime = performance.now();
-                    console.log(`compile ImageShader[${i}]: ${endTime - startTime} ms`);
+                    console.log(`compile imageShader[${i}]: ${endTime - startTime} ms`);
                 }
 
                 passIndex++;


### PR DESCRIPTION
シェーダーのコンパイル時間を計測する。

## キャッシュされていない場合

```
compile ImageShader[0]: 11734.304999990854 ms
compile soundShader: 3021.50500001153 ms
```

## キャッシュされた場合

```
compile ImageShader[0]: 363.149999990128 ms
compile ImageShader[1]: 5.400000023655593 ms
compile soundShader: 260.35500000580214 ms
```